### PR TITLE
(fix) remove undefined get-composer dependency from phpstan target

### DIFF
--- a/buildfile.xml
+++ b/buildfile.xml
@@ -563,7 +563,7 @@ Deny from all
 		<delete file="${database_dump.name}"></delete>
 	</target>
 
-	<target name="phpstan" depends="get-composer">
+	<target name="phpstan">
         <!--
             Example CLI use: `phing phpstan -Dphpstan.level=2`
         -->


### PR DESCRIPTION
Remove the get-composer dependency on the phpstan target so that phing functions correctly without intervention