### PR TITLE
(feat) adjust .htaccess creation to suit SS4 public dir usage

### DIFF
--- a/build.properties.sample
+++ b/build.properties.sample
@@ -20,6 +20,7 @@ modules.core.file=build/core-modules
 local.php.config=build/configs/silverstripe/.env.sample
 local.yml.config=build/configs/silverstripe/local.sample.yml
 htaccess.config=build/configs/silverstripe/htaccess.sample
+htaccess-root-public.config=build/configs/silverstripe/htaccess-root-public.sample
 
 # change this to the value that appears AFTER the TLD in your url
 # the below matches http://localhost/silverstripe

--- a/buildfile.xml
+++ b/buildfile.xml
@@ -200,12 +200,26 @@ Allow from 127.0.0.1
 			<available file="${project.root}/${htaccess.config}" />
 			<then><property name="config_prefix" value="${project.root}/" override="true" /></then>
 		</if>
-		<!-- Copy the htaccess -->
-		<copy tofile=".htaccess" file="${config_prefix}${htaccess.config}" overwrite="false">
-			<filterchain>
-				<expandproperties />
-			</filterchain>
-		</copy>
+		<!-- Copy the htaccess - checking for public directory layout -->
+		<if>
+			<available file="public" type="dir" />
+			<then>
+				<exec command="touch -c public/.htaccess" checkreturn="true" />
+				<copy tofile="public/.htaccess" file="${config_prefix}${htaccess.config}" overwrite="false">
+					<filterchain>
+						<expandproperties />
+					</filterchain>
+				</copy>
+				<copy tofile=".htaccess" file="${config_prefix}${htaccess-root-public.config}" overwrite="false" />
+			</then>
+			<else>
+				<copy tofile=".htaccess" file="${config_prefix}${htaccess.config}" overwrite="false">
+					<filterchain>
+						<expandproperties />
+					</filterchain>
+				</copy>
+			</else>
+		</if>
 	</target>
 
 	<!-- A target that gets executed if the 'ni_build' parameter is set. This is done when

--- a/configs/silverstripe/htaccess-root-public.sample
+++ b/configs/silverstripe/htaccess-root-public.sample
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^(.*)$ public/$1


### PR DESCRIPTION
Adjust the .htaccess setup logic to check for the Silverstripe 4.x public directory structure.

Backwards compatibility maintained.