### PR TITLE
fix: Add quotes in local.sample.yml

### DIFF
--- a/configs/silverstripe/local.sample.yml
+++ b/configs/silverstripe/local.sample.yml
@@ -26,7 +26,7 @@ Name: ss-log-file
 SilverStripe\Core\Injector\Injector:
   Psr\Log\LoggerInterface:
     calls:
-      LogFileHandler: [ pushHandler, [ %$LogFileHandler ] ]
+      LogFileHandler: [ pushHandler, [ '%$LogFileHandler' ] ]
   LogFileHandler:
     class: Monolog\Handler\StreamHandler
     constructor:


### PR DESCRIPTION
Needed to add those quotes as it breaks the dev/build with newer versions of SilverStripe.